### PR TITLE
fix: sync fail when sync secrets is false

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -20,9 +20,9 @@ type Connector struct {
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
 	builders := []connectorbuilder.ResourceSyncer{
-		newUserBuilder(d.Client),
+		newUserBuilder(d.Client, d.syncSecrets),
 		newAccountRoleBuilder(d.Client),
-		newDatabaseBuilder(d.Client),
+		newDatabaseBuilder(d.Client, d.syncSecrets),
 	}
 
 	if d.syncSecrets {

--- a/pkg/connector/databases.go
+++ b/pkg/connector/databases.go
@@ -16,13 +16,14 @@ import (
 type databaseBuilder struct {
 	resourceType *v2.ResourceType
 	client       *snowflake.Client
+	syncSecrets  bool
 }
 
 func (o *databaseBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 	return databaseResourceType
 }
 
-func databaseResource(database *snowflake.Database) (*v2.Resource, error) {
+func databaseResource(database *snowflake.Database, syncSecrets bool) (*v2.Resource, error) {
 	profile := map[string]interface{}{
 		"name": database.Name,
 	}
@@ -31,8 +32,18 @@ func databaseResource(database *snowflake.Database) (*v2.Resource, error) {
 		rs.WithAppProfile(profile),
 	}
 
+	var opts []rs.ResourceOption
+	if syncSecrets {
+		opts = append(opts, rs.WithAnnotation(&v2.ChildResourceType{ResourceTypeId: secretResourceType.Id}))
+	}
+
 	resource, err := rs.NewAppResource(
-		database.Name, databaseResourceType, database.Name, databaseTraits, rs.WithAnnotation(&v2.ChildResourceType{ResourceTypeId: secretResourceType.Id}))
+		database.Name,
+		databaseResourceType,
+		database.Name,
+		databaseTraits,
+		opts...,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +64,7 @@ func (o *databaseBuilder) List(ctx context.Context, parentResourceID *v2.Resourc
 
 	var resources []*v2.Resource
 	for _, database := range databases {
-		resource, err := databaseResource(&database) // #nosec G601
+		resource, err := databaseResource(&database, o.syncSecrets) // #nosec G601
 		if err != nil {
 			return nil, "", nil, wrapError(err, "failed to create database resource")
 		}
@@ -125,9 +136,10 @@ func (o *databaseBuilder) Grants(ctx context.Context, resource *v2.Resource, pTo
 	return grants, "", nil, nil
 }
 
-func newDatabaseBuilder(client *snowflake.Client) *databaseBuilder {
+func newDatabaseBuilder(client *snowflake.Client, syncSecrets bool) *databaseBuilder {
 	return &databaseBuilder{
 		resourceType: databaseResourceType,
 		client:       client,
+		syncSecrets:  syncSecrets,
 	}
 }


### PR DESCRIPTION
We have the ChildResource Annotation, this annotation will trigger a new List call for secretResource with the database parentId

We have the ChildResource Annotation, this annotation will trigger a new List call for secretResource with the database parentId
https://github.com/ConductorOne/baton-snowflake/blob/main/pkg/connector/databases.go#L35

But, since it's an conditional builder method on https://github.com/ConductorOne/baton-snowflake/blob/main/pkg/connector/connector.go#L28

It will not call https://github.com/ConductorOne/baton-snowflake/blob/main/pkg/connector/secrets.go#L19

So the sdk does not knows the secretResourceType https://conductorone.slack.com/archives/D08JKP676VB/p1742490873708329
That's why we have the error when List database when the sync-secrets it's false

## Solution

We need to give the options for https://github.com/ConductorOne/baton-snowflake/blob/main/pkg/connector/databases.go#L35
only if the config to sync-secrets its true