### PR TITLE
[CXP-446] Fix period in resource names causing table ID parsing failures

### DIFF
--- a/pkg/connector/tables.go
+++ b/pkg/connector/tables.go
@@ -214,9 +214,26 @@ func (o *tableBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 }
 
 func parseTableResourceID(resource *v2.Resource) (string, string, string, error) {
+	// Prefer profile fields — they store the raw names without delimiter ambiguity.
+	// This correctly handles periods in database, schema, or table names.
+	appTrait, err := rs.GetAppTrait(resource)
+	if err == nil && appTrait.GetProfile() != nil {
+		profile := appTrait.GetProfile()
+		dbName, dbOk := rs.GetProfileStringValue(profile, "database_name")
+		schemaName, schemaOk := rs.GetProfileStringValue(profile, "schema_name")
+		tableName, nameOk := rs.GetProfileStringValue(profile, "name")
+		if dbOk && schemaOk && nameOk && dbName != "" && schemaName != "" && tableName != "" {
+			return dbName, schemaName, tableName, nil
+		}
+	}
+
+	// Fallback for legacy resources without profile fields.
 	parts := strings.Split(resource.Id.Resource, ".")
 	if len(parts) != 3 {
-		return "", "", "", wrapError(fmt.Errorf("invalid table resource ID format: %s", resource.Id.Resource), "expected format: database.schema.table")
+		return "", "", "", wrapError(
+			fmt.Errorf("invalid table resource ID format: %s", resource.Id.Resource),
+			"expected format: database.schema.table",
+		)
 	}
 	return parts[0], parts[1], parts[2], nil
 }

--- a/pkg/connector/tables_test.go
+++ b/pkg/connector/tables_test.go
@@ -1,0 +1,146 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-snowflake/pkg/snowflake"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTableResource creates a table resource with profile fields via the real tableResource() function.
+func makeTableResource(t *testing.T, dbName, schemaName, tableName string) *v2.Resource {
+	t.Helper()
+	table := &snowflake.Table{
+		DatabaseName: dbName,
+		SchemaName:   schemaName,
+		Name:         tableName,
+		Kind:         "TABLE",
+		CreatedOn:    time.Now(),
+	}
+	parentID := &v2.ResourceId{
+		ResourceType: databaseResourceType.Id,
+		Resource:     dbName,
+	}
+	resource, err := tableResource(context.Background(), table, parentID, false)
+	require.NoError(t, err)
+	return resource
+}
+
+// makeBareResource creates a resource with a raw ID string and no profile (simulates legacy sync).
+func makeBareResource(t *testing.T, resourceID string) *v2.Resource {
+	t.Helper()
+	return &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: tableResourceType.Id,
+			Resource:     resourceID,
+		},
+	}
+}
+
+func TestParseTableResourceID(t *testing.T) {
+	tests := []struct {
+		name       string
+		resource   *v2.Resource
+		wantDB     string
+		wantSchema string
+		wantTable  string
+		wantErr    bool
+	}{
+		{
+			name:       "normal names with profile",
+			resource:   makeTableResource(t, "mydb", "public", "users"),
+			wantDB:     "mydb",
+			wantSchema: "public",
+			wantTable:  "users",
+		},
+		{
+			name:       "period in database name",
+			resource:   makeTableResource(t, "my.db", "public", "users"),
+			wantDB:     "my.db",
+			wantSchema: "public",
+			wantTable:  "users",
+		},
+		{
+			name:       "period in schema name",
+			resource:   makeTableResource(t, "mydb", "my.schema", "users"),
+			wantDB:     "mydb",
+			wantSchema: "my.schema",
+			wantTable:  "users",
+		},
+		{
+			name:       "period in table name",
+			resource:   makeTableResource(t, "mydb", "public", "my.table"),
+			wantDB:     "mydb",
+			wantSchema: "public",
+			wantTable:  "my.table",
+		},
+		{
+			name:       "periods in all components",
+			resource:   makeTableResource(t, "a.b", "c.d", "e.f"),
+			wantDB:     "a.b",
+			wantSchema: "c.d",
+			wantTable:  "e.f",
+		},
+		{
+			name:       "legacy fallback with valid format",
+			resource:   makeBareResource(t, "mydb.public.users"),
+			wantDB:     "mydb",
+			wantSchema: "public",
+			wantTable:  "users",
+		},
+		{
+			name:     "legacy fallback with invalid format",
+			resource: makeBareResource(t, "mydb.public"),
+			wantErr:  true,
+		},
+		{
+			name:       "partial profile falls back to split",
+			resource:   makePartialProfileResource(t, "mydb", "public", "users"),
+			wantDB:     "mydb",
+			wantSchema: "public",
+			wantTable:  "users",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, schema, table, err := parseTableResourceID(tt.resource)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantDB, db)
+			require.Equal(t, tt.wantSchema, schema)
+			require.Equal(t, tt.wantTable, table)
+		})
+	}
+}
+
+// makePartialProfileResource creates a resource with profile missing the "name" field,
+// forcing a fallback to the split-based parsing.
+func makePartialProfileResource(t *testing.T, dbName, schemaName, tableName string) *v2.Resource {
+	t.Helper()
+	profile := map[string]interface{}{
+		"database_name": dbName,
+		"schema_name":   schemaName,
+		// "name" intentionally omitted
+	}
+	tableTraits := []rs.AppTraitOption{
+		rs.WithAppProfile(profile),
+	}
+	tableId := fmt.Sprintf("%s.%s.%s", dbName, schemaName, tableName)
+	resource, err := rs.NewAppResource(
+		tableName,
+		tableResourceType,
+		tableId,
+		tableTraits,
+	)
+	require.NoError(t, err)
+	return resource
+}


### PR DESCRIPTION
## Summary

- Snowflake allows periods in quoted database, schema, and table identifiers. The connector's `parseTableResourceID()` split resource IDs on `.` to extract name components, which broke when any component contained a period — crashing sync with an "invalid table resource ID format" error.
- Fix reads name components from the resource's App profile attributes (`database_name`, `schema_name`, `name`) instead of splitting the composite ID string. Falls back to the old split for backward compatibility.
- Adds unit tests covering periods in each component, all components, legacy fallback, and partial profile fallback.

## Test plan

- [x] `go build ./cmd/baton-snowflake` passes
- [x] `go test ./pkg/connector/ -run TestParseTableResourceID -v` — all 9 tests pass
- [x] `go vet ./...` clean
- [x] Manual test with a Snowflake account containing database/schema/table names with periods

🤖 Generated with [Claude Code](https://claude.com/claude-code)