### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -74,7 +74,7 @@ Find your account identifier by navigating in the Snowflake console to your acco
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Snowflake connector
 
@@ -139,7 +139,7 @@ Click **Save**.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your Snowflake connector is now pulling access data into C1.
+**Done.** Your Snowflake connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Snowflake connector, hosted and run in your own environment.**
@@ -257,7 +257,7 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Snowflake connector to. Snowflake data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your Snowflake connector is now pulling access data into C1.
+**Done.** Your Snowflake connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site. Specific fixes depend on the connector — may include one or more of:

- Restore \`**Done.**\` closing phrase (replaces \`**That's it!**\`)
- Restore correct check icon color (\`#c937ae\`)
- Restore \`BATON_PROVISIONING: true\` flag in Kubernetes secrets block (with comment)

These corrections prevent the sync bot from reintroducing regressions on future runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)