### PR TITLE
CXH-1407: speed up Snowflake table sync

### DIFF
--- a/cmd/baton-snowflake/main.go
+++ b/cmd/baton-snowflake/main.go
@@ -2,16 +2,10 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
-	sdkConfig "github.com/conductorone/baton-sdk/pkg/config"
-	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
-	"github.com/conductorone/baton-sdk/pkg/types"
-	"github.com/conductorone/baton-snowflake/pkg/config"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
-
+	"github.com/conductorone/baton-sdk/pkg/config"
+	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
+	cfg "github.com/conductorone/baton-snowflake/pkg/config"
 	"github.com/conductorone/baton-snowflake/pkg/connector"
 )
 
@@ -22,40 +16,5 @@ const (
 
 func main() {
 	ctx := context.Background()
-	_, cmd, err := sdkConfig.DefineConfiguration(ctx,
-		connectorName,
-		getConnector,
-		config.ConfigurationSchema(),
-	)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	cmd.Version = version
-	err = cmd.Execute()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-}
-
-func getConnector(ctx context.Context, cfg *config.Snowflake) (types.ConnectorServer, error) {
-	l := ctxzap.Extract(ctx)
-	cb, err := connector.New(
-		ctx,
-		cfg,
-	)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	c, err := connectorbuilder.NewConnector(ctx, cb)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	return c, nil
+	config.RunConnector(ctx, connectorName, version, cfg.ConfigurationSchema(), connector.New, connectorrunner.WithSessionStoreEnabled())
 }

--- a/pkg/connector/account_roles.go
+++ b/pkg/connector/account_roles.go
@@ -51,6 +51,10 @@ func (o *accountRoleBuilder) List(ctx context.Context, parentResourceID *v2.Reso
 		return nil, nil, wrapError(err, "failed to list account roles")
 	}
 
+	if err := o.client.CacheAccountRoles(ctx, opts.Session, accountRoles); err != nil {
+		return nil, nil, wrapError(err, "failed to seed account role cache")
+	}
+
 	var resources []*v2.Resource
 	for _, role := range accountRoles {
 		resource, err := accountRoleResource(&role) // #nosec G601

--- a/pkg/connector/account_roles.go
+++ b/pkg/connector/account_roles.go
@@ -25,7 +25,7 @@ func (o *accountRoleBuilder) ResourceType(ctx context.Context) *v2.ResourceType 
 
 func accountRoleResource(accountRole *snowflake.AccountRole) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"name": accountRole.Name,
+		profileKeyName: accountRole.Name,
 	}
 
 	roleTraits := []rs.RoleTraitOption{

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -53,7 +53,7 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 		Description: "Connector syncing users, databases, tables, and account roles from Snowflake.",
 		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
 			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
-				"name": {
+				profileKeyName: {
 					DisplayName: "User Name",
 					Required:    true,
 					Description: "The name of the user (required - case-sensitive)",
@@ -113,7 +113,7 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
 					},
 				},
-				"comment": {
+				profileKeyComment: {
 					DisplayName: "Comment",
 					Required:    false,
 					Description: "A comment or description for the user",

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -7,6 +7,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/conductorone/baton-snowflake/pkg/config"
@@ -192,26 +193,26 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, cfg *config.Snowflake) (*Connector, error) {
+func New(ctx context.Context, cfg *config.Snowflake, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
 	if cfg.PrivateKeyPath == "" && len(cfg.PrivateKey) == 0 {
-		return nil, fmt.Errorf("private-key or private-key-path is required")
+		return nil, nil, fmt.Errorf("private-key or private-key-path is required")
 	}
 	if cfg.PrivateKeyPath != "" && len(cfg.PrivateKey) > 0 {
-		return nil, fmt.Errorf("only one of private-key or private-key-path can be provided")
+		return nil, nil, fmt.Errorf("only one of private-key or private-key-path can be provided")
 	}
 	var privateKeyValue any
 	if cfg.PrivateKeyPath != "" {
 		var err error
 		privateKeyValue, err = snowflake.ReadPrivateKey(cfg.PrivateKeyPath)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 	if len(cfg.PrivateKey) > 0 {
 		var err error
 		privateKeyValue, err = snowflake.ParsePrivateKey(cfg.PrivateKey)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -223,7 +224,7 @@ func New(ctx context.Context, cfg *config.Snowflake) (*Connector, error) {
 	noAuth := uhttp.NoAuth{}
 	baseHttpClient, err := noAuth.GetClient(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	ts := snowflake.NewJWTTokenSource(&jwtConfig)
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, baseHttpClient)
@@ -231,11 +232,11 @@ func New(ctx context.Context, cfg *config.Snowflake) (*Connector, error) {
 
 	client, err := snowflake.New(cfg.AccountUrl, jwtConfig, httpClient)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	return &Connector{
 		Client:      client,
 		syncSecrets: cfg.SyncSecrets,
-	}, nil
+	}, nil, nil
 }

--- a/pkg/connector/databases.go
+++ b/pkg/connector/databases.go
@@ -26,7 +26,7 @@ func (o *databaseBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 
 func databaseResource(database *snowflake.Database, syncSecrets bool) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"name":                database.Name,
+		profileKeyName:        database.Name,
 		"kind":                database.Kind,
 		"origin":              database.Origin,
 		"is_shared_or_system": database.IsSharedOrSystem(),

--- a/pkg/connector/databases.go
+++ b/pkg/connector/databases.go
@@ -102,7 +102,7 @@ func (o *databaseBuilder) Entitlements(_ context.Context, resource *v2.Resource,
 	return rv, nil, nil
 }
 
-func (o *databaseBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+func (o *databaseBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	database, _, err := o.client.GetDatabase(ctx, resource.Id.Resource)
 	if err != nil {
 		return nil, nil, wrapError(err, "failed to get database")
@@ -111,7 +111,7 @@ func (o *databaseBuilder) Grants(ctx context.Context, resource *v2.Resource, _ r
 		return nil, nil, nil
 	}
 
-	owner, ownerStatusCode, err := o.client.GetAccountRole(ctx, database.Owner)
+	owner, ownerStatusCode, err := o.client.GetAccountRole(ctx, opts.Session, database.Owner)
 	if err != nil {
 		if snowflake.IsUnprocessableEntity(ownerStatusCode, err) {
 			wrappedErr := fmt.Errorf("baton-snowflake: insufficient privileges for database owner role %q (database %q): %w", database.Owner, resource.Id.Resource, err)

--- a/pkg/connector/profile_keys.go
+++ b/pkg/connector/profile_keys.go
@@ -1,0 +1,6 @@
+package connector
+
+const (
+	profileKeyName    = "name"
+	profileKeyComment = "comment"
+)

--- a/pkg/connector/tables.go
+++ b/pkg/connector/tables.go
@@ -275,7 +275,7 @@ func (o *tableBuilder) Entitlements(ctx context.Context, resource *v2.Resource, 
 	}
 
 	objectKind := getObjectKind(resource)
-	tableGrants, err := o.client.ListTableGrants(ctx, databaseName, schemaName, tableName, objectKind)
+	tableGrants, err := o.client.ListTableGrants(ctx, opts.Session, databaseName, schemaName, tableName, objectKind)
 	if err != nil {
 		return nil, nil, wrapError(err, fmt.Sprintf("failed to list table grants for %s", resource.Id.Resource))
 	}
@@ -315,7 +315,7 @@ func (o *tableBuilder) Grants(ctx context.Context, resource *v2.Resource, opts r
 	}
 
 	objectKind := getObjectKind(resource)
-	tableGrants, err := o.client.ListTableGrants(ctx, databaseName, schemaName, tableName, objectKind)
+	tableGrants, err := o.client.ListTableGrants(ctx, opts.Session, databaseName, schemaName, tableName, objectKind)
 	if err != nil {
 		return nil, nil, wrapError(err, "failed to list table grants")
 	}
@@ -334,7 +334,7 @@ func (o *tableBuilder) Grants(ctx context.Context, resource *v2.Resource, opts r
 
 		switch tg.GrantedTo {
 		case grantedToRole:
-			role, statusCode, err := o.client.GetAccountRole(ctx, tg.GranteeName)
+			role, statusCode, err := o.client.GetAccountRole(ctx, opts.Session, tg.GranteeName)
 			if err != nil {
 				if snowflake.IsUnprocessableEntity(statusCode, err) {
 					principalId, idErr := rs.NewResourceID(accountRoleResourceType, tg.GranteeName)
@@ -364,7 +364,7 @@ func (o *tableBuilder) Grants(ctx context.Context, resource *v2.Resource, opts r
 				ownerExpandableRoleName = role.Name
 			}
 		case grantedToUser:
-			user, _, err := o.client.GetUser(ctx, tg.GranteeName)
+			user, _, err := o.client.GetUser(ctx, opts.Session, tg.GranteeName)
 			if err != nil {
 				return nil, nil, wrapError(err, fmt.Sprintf("failed to get user %q for table grants", tg.GranteeName))
 			}
@@ -394,7 +394,7 @@ func (o *tableBuilder) Grants(ctx context.Context, resource *v2.Resource, opts r
 			return nil, nil, wrapError(err, "failed to get table for owner fallback")
 		}
 		if table != nil && table.Owner != "" && table.Owner != "SNOWFLAKE" {
-			owner, ownerStatusCode, err := o.client.GetAccountRole(ctx, table.Owner)
+			owner, ownerStatusCode, err := o.client.GetAccountRole(ctx, opts.Session, table.Owner)
 			switch {
 			case snowflake.IsUnprocessableEntity(ownerStatusCode, err):
 				// system role, skip

--- a/pkg/connector/tables.go
+++ b/pkg/connector/tables.go
@@ -93,11 +93,11 @@ func (o *tableBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 
 func tableResource(_ context.Context, table *snowflake.Table, id *v2.ResourceId, isSharedOrSystemDB bool) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"name":                      table.Name,
+		profileKeyName:              table.Name,
 		"schema_name":               table.SchemaName,
 		"database_name":             table.DatabaseName,
 		"kind":                      table.Kind,
-		"comment":                   table.Comment,
+		profileKeyComment:           table.Comment,
 		"owner":                     table.Owner,
 		"created_on":                table.CreatedOn.Format("2006-01-02 15:04:05.999"),
 		"database_is_shared_system": isSharedOrSystemDB,
@@ -221,7 +221,7 @@ func parseTableResourceID(resource *v2.Resource) (string, string, string, error)
 		profile := appTrait.GetProfile()
 		dbName, dbOk := rs.GetProfileStringValue(profile, "database_name")
 		schemaName, schemaOk := rs.GetProfileStringValue(profile, "schema_name")
-		tableName, nameOk := rs.GetProfileStringValue(profile, "name")
+		tableName, nameOk := rs.GetProfileStringValue(profile, profileKeyName)
 		if dbOk && schemaOk && nameOk && dbName != "" && schemaName != "" && tableName != "" {
 			return dbName, schemaName, tableName, nil
 		}

--- a/pkg/connector/tables.go
+++ b/pkg/connector/tables.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-snowflake/pkg/snowflake"
 )

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -329,7 +329,7 @@ func (o *userBuilder) fetchUserWithSQLRetry(ctx context.Context, userName string
 	baseDelay := 500 * time.Millisecond
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		user, statusCode, err := o.client.GetUser(ctx, userName)
+		user, statusCode, err := o.client.GetUser(ctx, nil, userName)
 		if err == nil && statusCode == http.StatusOK {
 			l.Debug("user fetched successfully via SQL API",
 				zap.String("user_name", userName),

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -174,6 +174,10 @@ func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 		return nil, nil, nil
 	}
 
+	if err := o.client.CacheUsers(ctx, opts.Session, users); err != nil {
+		return nil, nil, wrapError(err, "failed to seed user cache")
+	}
+
 	var resources []*v2.Resource
 	for _, user := range users {
 		resource, err := userResource(ctx, &user, o.syncSecrets) // #nosec G601

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -32,12 +32,12 @@ func (o *userBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 
 func userResource(_ context.Context, user *snowflake.User, syncSecrets bool) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"email":        user.Email,
-		"login":        user.Login,
-		"display_name": user.DisplayName,
-		"first_name":   user.FirstName,
-		"last_name":    user.LastName,
-		"comment":      user.Comment,
+		"email":           user.Email,
+		"login":           user.Login,
+		"display_name":    user.DisplayName,
+		"first_name":      user.FirstName,
+		"last_name":       user.LastName,
+		profileKeyComment: user.Comment,
 	}
 
 	userTraits := []rs.UserTraitOption{
@@ -135,7 +135,7 @@ func extractProfileFields(accountInfo *v2.AccountInfo, createReq *snowflake.Crea
 	if emailStr, ok := pMap["email"].(string); ok && emailStr != "" {
 		createReq.Email = emailStr
 	}
-	if commentStr, ok := pMap["comment"].(string); ok && commentStr != "" {
+	if commentStr, ok := pMap[profileKeyComment].(string); ok && commentStr != "" {
 		createReq.Comment = commentStr
 	}
 	// Handle disabled as boolean
@@ -229,7 +229,7 @@ func (o *userBuilder) CreateAccount(
 	// The user name must be provided in profile.name (required in schema)
 	userName := ""
 	if profile := accountInfo.GetProfile(); profile != nil {
-		if nameStr, ok := rs.GetProfileStringValue(profile, "name"); ok && nameStr != "" {
+		if nameStr, ok := rs.GetProfileStringValue(profile, profileKeyName); ok && nameStr != "" {
 			userName = nameStr
 		}
 	}

--- a/pkg/snowflake/account_role.go
+++ b/pkg/snowflake/account_role.go
@@ -3,7 +3,10 @@ package snowflake
 import (
 	"context"
 	"fmt"
+	"net/http"
 
+	"github.com/conductorone/baton-sdk/pkg/session"
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -138,7 +141,13 @@ func (c *Client) ListAccountRoleGrantees(ctx context.Context, roleName string) (
 	return accountRoleGrantees, nil
 }
 
-func (c *Client) GetAccountRole(ctx context.Context, roleName string) (*AccountRole, int, error) {
+func (c *Client) GetAccountRole(ctx context.Context, ss sessions.SessionStore, roleName string) (*AccountRole, int, error) {
+	if ss != nil {
+		if cached, found, err := session.GetJSON[*AccountRole](ctx, ss, roleName, accountRoleNamespace); err == nil && found {
+			return cached, http.StatusOK, nil
+		}
+	}
+
 	queries := []string{
 		fmt.Sprintf("SHOW ROLES LIKE '%s' LIMIT 1;", roleName),
 	}
@@ -164,11 +173,16 @@ func (c *Client) GetAccountRole(ctx context.Context, roleName string) (*AccountR
 		return nil, resp.StatusCode, err
 	}
 
-	if len(accountRoles) == 0 {
-		return nil, resp.StatusCode, nil
+	var role *AccountRole
+	if len(accountRoles) > 0 {
+		role = &accountRoles[0]
 	}
 
-	return &accountRoles[0], resp.StatusCode, nil
+	if ss != nil {
+		_ = session.SetJSON(ctx, ss, roleName, role, accountRoleNamespace)
+	}
+
+	return role, resp.StatusCode, nil
 }
 
 func (c *Client) GrantAccountRole(ctx context.Context, roleName, userName string) error {

--- a/pkg/snowflake/account_role.go
+++ b/pkg/snowflake/account_role.go
@@ -141,6 +141,21 @@ func (c *Client) ListAccountRoleGrantees(ctx context.Context, roleName string) (
 	return accountRoleGrantees, nil
 }
 
+func (c *Client) CacheAccountRoles(ctx context.Context, ss sessions.SessionStore, roles []AccountRole) error {
+	if ss == nil || len(roles) == 0 {
+		return nil
+	}
+	m := make(map[string]*AccountRole, len(roles))
+	for i := range roles {
+		role := roles[i]
+		m[role.Name] = &role
+	}
+	if err := session.SetManyJSON(ctx, ss, m, accountRoleNamespace); err != nil {
+		return fmt.Errorf("snowflake: cache account roles: %w", err)
+	}
+	return nil
+}
+
 func (c *Client) GetAccountRole(ctx context.Context, ss sessions.SessionStore, roleName string) (*AccountRole, int, error) {
 	if ss != nil {
 		if cached, found, err := session.GetJSON[*AccountRole](ctx, ss, roleName, accountRoleNamespace); err == nil && found {

--- a/pkg/snowflake/account_role.go
+++ b/pkg/snowflake/account_role.go
@@ -13,7 +13,7 @@ import (
 )
 
 var accountRoleStructFieldToColumnMap = map[string]string{
-	"Name": "name",
+	structFieldName: columnName,
 }
 
 type (

--- a/pkg/snowflake/client.go
+++ b/pkg/snowflake/client.go
@@ -11,7 +11,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
+)
+
+var (
+	accountRoleNamespace = sessions.WithPrefix("account_role")
+	userNamespace        = sessions.WithPrefix("user")
+	tableGrantsNamespace = sessions.WithPrefix("table_grants")
 )
 
 const (

--- a/pkg/snowflake/columns.go
+++ b/pkg/snowflake/columns.go
@@ -1,0 +1,17 @@
+package snowflake
+
+const (
+	structFieldName         = "Name"
+	structFieldOwner        = "Owner"
+	structFieldComment      = "Comment"
+	structFieldCreatedOn    = "CreatedOn"
+	structFieldDatabaseName = "DatabaseName"
+)
+
+const (
+	columnName         = "name"
+	columnOwner        = "owner"
+	columnComment      = "comment"
+	columnCreatedOn    = "created_on"
+	columnDatabaseName = "database_name"
+)

--- a/pkg/snowflake/database.go
+++ b/pkg/snowflake/database.go
@@ -11,10 +11,10 @@ import (
 )
 
 var databaseStructFieldToColumnMap = map[string]string{
-	"Name":   "name",
-	"Owner":  "owner",
-	"Kind":   "kind",
-	"Origin": "origin",
+	structFieldName:  columnName,
+	structFieldOwner: columnOwner,
+	"Kind":           "kind",
+	"Origin":         "origin",
 }
 
 type (

--- a/pkg/snowflake/table.go
+++ b/pkg/snowflake/table.go
@@ -19,8 +19,8 @@ import (
 )
 
 var schemaStructFieldToColumnMap = map[string]string{
-	"Name":         "name",
-	"DatabaseName": "database_name",
+	structFieldName:         columnName,
+	structFieldDatabaseName: columnDatabaseName,
 }
 
 type (
@@ -94,13 +94,13 @@ func (c *Client) ListSchemasInDatabase(ctx context.Context, databaseName string)
 }
 
 var tableStructFieldToColumnMap = map[string]string{
-	"CreatedOn":    "created_on",
-	"Name":         "name",
-	"SchemaName":   "schema_name",
-	"DatabaseName": "database_name",
-	"Kind":         "kind",
-	"Comment":      "comment",
-	"Owner":        "owner",
+	structFieldCreatedOn:    columnCreatedOn,
+	structFieldName:         columnName,
+	"SchemaName":            "schema_name",
+	structFieldDatabaseName: columnDatabaseName,
+	"Kind":                  "kind",
+	structFieldComment:      columnComment,
+	structFieldOwner:        columnOwner,
 }
 
 type (
@@ -264,14 +264,14 @@ func (c *Client) GetTable(ctx context.Context, database, schema, tableName strin
 }
 
 var tableGrantStructFieldToColumnMap = map[string]string{
-	"CreatedOn":   "created_on",
-	"Privilege":   "privilege",
-	"GrantedOn":   "granted_on",
-	"Name":        "name",
-	"GrantedTo":   "granted_to",
-	"GranteeName": "grantee_name",
-	"GrantOption": "grant_option",
-	"GrantedBy":   "granted_by",
+	structFieldCreatedOn: columnCreatedOn,
+	"Privilege":          "privilege",
+	"GrantedOn":          "granted_on",
+	structFieldName:      columnName,
+	"GrantedTo":          "granted_to",
+	"GranteeName":        "grantee_name",
+	"GrantOption":        "grant_option",
+	"GrantedBy":          "granted_by",
 }
 
 type (

--- a/pkg/snowflake/table.go
+++ b/pkg/snowflake/table.go
@@ -13,6 +13,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/conductorone/baton-sdk/pkg/session"
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 )
 
@@ -306,8 +308,23 @@ func (r *ListTableGrantsRawResponse) GetTableGrants() ([]TableGrant, error) {
 	return grants, nil
 }
 
+func tableGrantsCacheKey(database, schema, tableName, objectKind string) string {
+	kind := "TABLE"
+	if strings.EqualFold(objectKind, "VIEW") {
+		kind = "VIEW"
+	}
+	return fmt.Sprintf("%s|%s|%s|%s", database, schema, tableName, kind)
+}
+
 // ListTableGrants uses objectKind to run SHOW GRANTS ON TABLE or ON VIEW (Snowflake requires the correct type).
-func (c *Client) ListTableGrants(ctx context.Context, database, schema, tableName, objectKind string) ([]TableGrant, error) {
+func (c *Client) ListTableGrants(ctx context.Context, ss sessions.SessionStore, database, schema, tableName, objectKind string) ([]TableGrant, error) {
+	cacheKey := tableGrantsCacheKey(database, schema, tableName, objectKind)
+	if ss != nil {
+		if cached, found, err := session.GetJSON[[]TableGrant](ctx, ss, cacheKey, tableGrantsNamespace); err == nil && found {
+			return cached, nil
+		}
+	}
+
 	l := ctxzap.Extract(ctx)
 	objectType := "TABLE"
 	if strings.EqualFold(objectKind, "VIEW") {
@@ -374,6 +391,10 @@ func (c *Client) ListTableGrants(ctx context.Context, database, schema, tableNam
 	grants, err := response.GetTableGrants()
 	if err != nil {
 		return nil, err
+	}
+
+	if ss != nil {
+		_ = session.SetJSON(ctx, ss, cacheKey, grants, tableGrantsNamespace)
 	}
 
 	return grants, nil

--- a/pkg/snowflake/user.go
+++ b/pkg/snowflake/user.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	userStructFieldToColumnMap = map[string]string{
-		"Username":         "name",
+		"Username":         columnName,
 		"Login":            "login_name",
 		"DisplayName":      "display_name",
 		"FirstName":        "first_name",
@@ -29,7 +29,7 @@ var (
 		"LastSuccessLogin": "last_success_login",
 		"Type":             "type",
 		"HasMfa":           "has_mfa",
-		"Comment":          "comment",
+		structFieldComment: columnComment,
 	}
 
 	// Sadly snowflake is inconsistent and returns different set of columns for DESC USER.
@@ -41,15 +41,15 @@ var (
 	}
 
 	secretStructFieldToColumnMap = map[string]string{
-		"CreatedOn":     "created_on",
-		"Name":          "name",
-		"SchemaName":    "schema_name",
-		"DatabaseName":  "database_name",
-		"Owner":         "owner",
-		"Comment":       "comment",
-		"SecretType":    "secret_type",
-		"OAuthScopes":   "oauth_scopes",
-		"OwnerRoleType": "owner_role_type",
+		structFieldCreatedOn:    columnCreatedOn,
+		structFieldName:         columnName,
+		"SchemaName":            "schema_name",
+		structFieldDatabaseName: columnDatabaseName,
+		structFieldOwner:        columnOwner,
+		structFieldComment:      columnComment,
+		"SecretType":            "secret_type",
+		"OAuthScopes":           "oauth_scopes",
+		"OwnerRoleType":         "owner_role_type",
 	}
 
 	userDescriptionStructFieldToColumnMap = map[string]string{

--- a/pkg/snowflake/user.go
+++ b/pkg/snowflake/user.go
@@ -3,10 +3,13 @@ package snowflake
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"time"
 
+	"github.com/conductorone/baton-sdk/pkg/session"
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 )
 
@@ -220,7 +223,13 @@ func (c *Client) ListUsers(ctx context.Context, cursor string, limit int) ([]Use
 	return users, nil
 }
 
-func (c *Client) GetUser(ctx context.Context, username string) (*User, int, error) {
+func (c *Client) GetUser(ctx context.Context, ss sessions.SessionStore, username string) (*User, int, error) {
+	if ss != nil {
+		if cached, found, err := session.GetJSON[*User](ctx, ss, username, userNamespace); err == nil && found {
+			return cached, http.StatusOK, nil
+		}
+	}
+
 	// Escape double quotes in username by doubling them before quoting
 	escapedUsername := escapeDoubleQuotedIdentifier(username)
 	queries := []string{
@@ -246,6 +255,10 @@ func (c *Client) GetUser(ctx context.Context, username string) (*User, int, erro
 	user, err := response.GetUser()
 	if err != nil {
 		return nil, resp.StatusCode, err
+	}
+
+	if ss != nil {
+		_ = session.SetJSON(ctx, ss, username, user, userNamespace)
 	}
 
 	return user, resp.StatusCode, nil

--- a/pkg/snowflake/user.go
+++ b/pkg/snowflake/user.go
@@ -223,6 +223,22 @@ func (c *Client) ListUsers(ctx context.Context, cursor string, limit int) ([]Use
 	return users, nil
 }
 
+// SHOW USERS returns a superset of DESCRIBE USER fields, so cached entries are safe to reuse for GetUser.
+func (c *Client) CacheUsers(ctx context.Context, ss sessions.SessionStore, users []User) error {
+	if ss == nil || len(users) == 0 {
+		return nil
+	}
+	m := make(map[string]*User, len(users))
+	for i := range users {
+		user := users[i]
+		m[user.Username] = &user
+	}
+	if err := session.SetManyJSON(ctx, ss, m, userNamespace); err != nil {
+		return fmt.Errorf("snowflake: cache users: %w", err)
+	}
+	return nil
+}
+
 func (c *Client) GetUser(ctx context.Context, ss sessions.SessionStore, username string) (*User, int, error) {
 	if ss != nil {
 		if cached, found, err := session.GetJSON[*User](ctx, ss, username, userNamespace); err == nil && found {


### PR DESCRIPTION
The Snowflake connector now reuses data within a sync instead of re-fetching it per table, so environments that previously took over a day should sync in a fraction of the time.