### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -243,7 +243,7 @@ spec:
     spec:
       containers:
       - name: baton-snowflake
-        image: ghcr.io/conductorone/baton-snowflake:latest
+        image: public.ecr.aws/conductorone/baton-snowflake:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -292,4 +292,3 @@ If user records are syncing but fields such as `LOGIN`, `DISPLAY_NAME`, and othe
 USE ROLE ACCOUNTADMIN;
 GRANT MANAGE GRANTS ON ACCOUNT TO USER <SERVICE ACCOUNT>;
 ```
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._