### PR TITLE
cxp-686 handle account roles grants partitions

### DIFF
--- a/pkg/connector/account_roles.go
+++ b/pkg/connector/account_roles.go
@@ -98,11 +98,17 @@ func (o *accountRoleBuilder) Entitlements(_ context.Context, resource *v2.Resour
 	return rv, &rs.SyncOpResults{}, nil
 }
 
-func (o *accountRoleBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	accountRoleGrantees, err := o.client.ListAccountRoleGrantees(ctx, resource.DisplayName)
+func (o *accountRoleBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	bag, cursor, err := parseCursorFromToken(opts.PageToken.Token, &v2.ResourceId{ResourceType: o.resourceType.Id})
+	if err != nil {
+		return nil, nil, wrapError(err, "failed to get next page offset")
+	}
+
+	accountRoleGrantees, nextCursor, err := o.client.ListAccountRoleGrantees(ctx, resource.DisplayName, cursor)
 	if err != nil {
 		return nil, nil, wrapError(err, "failed to list account role grantees")
 	}
+
 	var grants []*v2.Grant
 	for _, grantee := range accountRoleGrantees {
 		switch grantee.GranteeType {
@@ -123,7 +129,16 @@ func (o *accountRoleBuilder) Grants(ctx context.Context, resource *v2.Resource, 
 		}
 	}
 
-	return grants, nil, nil
+	if nextCursor == "" {
+		return grants, nil, nil
+	}
+
+	nextToken, err := bag.NextToken(nextCursor)
+	if err != nil {
+		return nil, nil, wrapError(err, "failed to create next page cursor")
+	}
+
+	return grants, &rs.SyncOpResults{NextPageToken: nextToken}, nil
 }
 
 func (o *accountRoleBuilder) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {

--- a/pkg/snowflake/account_role.go
+++ b/pkg/snowflake/account_role.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/conductorone/baton-sdk/pkg/session"
 	"github.com/conductorone/baton-sdk/pkg/types/sessions"
@@ -109,36 +111,81 @@ func (c *Client) ListAccountRoles(ctx context.Context, cursor string, limit int)
 	return accountRoles, nil
 }
 
-func (c *Client) ListAccountRoleGrantees(ctx context.Context, roleName string) ([]AccountRoleGrantee, error) {
-	queries := []string{
-		fmt.Sprintf("SHOW GRANTS OF ROLE \"%s\";", roleName),
-	}
-
-	req, err := c.PostStatementRequest(ctx, queries)
-	if err != nil {
-		return nil, err
-	}
-
+// ListAccountRoleGrantees returns one page of grantees for the given role.
+// cursor is empty on the first call; subsequent calls pass the opaque cursor returned by the previous call.
+// The returned cursor is empty when all pages have been consumed.
+// Cursor format (internal): "{statementHandle}:{partitionID}:{totalPartitions}".
+func (c *Client) ListAccountRoleGrantees(ctx context.Context, roleName string, cursor string) ([]AccountRoleGrantee, string, error) {
 	var response ListAccountRoleGranteesRawResponse
-	resp1, err := c.Do(req, uhttp.WithJSONResponse(&response))
-	defer closeResponseBody(resp1)
-	if err != nil {
-		return nil, err
+
+	if cursor == "" {
+		queries := []string{fmt.Sprintf("SHOW GRANTS OF ROLE \"%s\";", roleName)}
+
+		req, err := c.PostStatementRequest(ctx, queries)
+		if err != nil {
+			return nil, "", err
+		}
+
+		resp1, err := c.Do(req, uhttp.WithJSONResponse(&response))
+		defer closeResponseBody(resp1)
+		if err != nil {
+			return nil, "", err
+		}
+
+		handle := response.StatementHandle
+
+		req, err = c.GetStatementResponse(ctx, handle)
+		if err != nil {
+			return nil, "", err
+		}
+		resp2, err := c.Do(req, uhttp.WithJSONResponse(&response))
+		defer closeResponseBody(resp2)
+		if err != nil {
+			return nil, "", err
+		}
+
+		numPartitions := len(response.ResultSetMetadata.PartitionInfo)
+		l := ctxzap.Extract(ctx)
+		l.Debug("ListAccountRoleGrantees", zap.String("role", roleName), zap.Int("numPartitions", numPartitions), zap.Int("numRows", response.ResultSetMetadata.NumRows))
+
+		var nextCursor string
+		if numPartitions > 1 {
+			nextCursor = fmt.Sprintf("%s:1:%d", handle, numPartitions)
+		}
+
+		return response.GetAccountRoleGrantees(), nextCursor, nil
 	}
 
-	req, err = c.GetStatementResponse(ctx, response.StatementHandle)
-	if err != nil {
-		return nil, err
+	// Subsequent calls: fetch the encoded partition directly.
+	parts := strings.SplitN(cursor, ":", 3)
+	if len(parts) != 3 {
+		return nil, "", fmt.Errorf("snowflake: invalid grantee page cursor")
 	}
-	resp2, err := c.Do(req, uhttp.WithJSONResponse(&response))
-	defer closeResponseBody(resp2)
+	handle := parts[0]
+	partitionID, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return nil, err
+		return nil, "", fmt.Errorf("snowflake: invalid partition ID in cursor: %w", err)
+	}
+	totalPartitions, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return nil, "", fmt.Errorf("snowflake: invalid partition count in cursor: %w", err)
+	}
+	req, err := c.GetStatementPartition(ctx, handle, partitionID)
+	if err != nil {
+		return nil, "", err
+	}
+	resp, err := c.Do(req, uhttp.WithJSONResponse(&response))
+	defer closeResponseBody(resp)
+	if err != nil {
+		return nil, "", err
 	}
 
-	accountRoleGrantees := response.GetAccountRoleGrantees()
+	var nextCursor string
+	if partitionID+1 < totalPartitions {
+		nextCursor = fmt.Sprintf("%s:%d:%d", handle, partitionID+1, totalPartitions)
+	}
 
-	return accountRoleGrantees, nil
+	return response.GetAccountRoleGrantees(), nextCursor, nil
 }
 
 func (c *Client) CacheAccountRoles(ctx context.Context, ss sessions.SessionStore, roles []AccountRole) error {

--- a/pkg/snowflake/account_role_test.go
+++ b/pkg/snowflake/account_role_test.go
@@ -1,0 +1,130 @@
+package snowflake
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// serveGrantees returns an httptest.Server that implements the Snowflake Statements
+// API for SHOW GRANTS OF ROLE. partition0Rows is returned on the initial GET
+// (partition 0); if partition1Rows is non-nil a second partition is advertised
+// and served on ?partition=1.
+func serveGrantees(t *testing.T, handle string, partition0Rows, partition1Rows [][]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+
+		switch r.Method {
+		case http.MethodPost:
+			// Step 1: execute statement → return handle only.
+			_ = enc.Encode(map[string]interface{}{
+				"statementHandle": handle,
+			})
+
+		case http.MethodGet:
+			_, hasPartition := r.URL.Query()["partition"]
+			if !hasPartition {
+				// Step 2: partition 0 + full partitionInfo metadata.
+				partitionInfo := []map[string]interface{}{
+					{"rowCount": len(partition0Rows)},
+				}
+				if partition1Rows != nil {
+					partitionInfo = append(partitionInfo, map[string]interface{}{
+						"rowCount": len(partition1Rows),
+					})
+				}
+				_ = enc.Encode(map[string]interface{}{
+					"statementHandle": handle,
+					"resultSetMetadata": map[string]interface{}{
+						"numRows":       len(partition0Rows) + len(partition1Rows),
+						"partitionInfo": partitionInfo,
+					},
+					"data": partition0Rows,
+				})
+			} else {
+				// Step 3: subsequent partition — data only, no metadata.
+				require.Equal(t, "1", r.URL.Query().Get("partition"), "only partition 1 expected in this test")
+				_ = enc.Encode(map[string]interface{}{
+					"data": partition1Rows,
+				})
+			}
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+}
+
+// granteeRow builds a data row in the order GetAccountRoleGrantees expects:
+// index 1 = roleName, index 2 = granteeType, index 3 = granteeName.
+func granteeRow(roleName, granteeType, granteeName string) []string {
+	return []string{"", roleName, granteeType, granteeName}
+}
+
+func TestListAccountRoleGrantees_SinglePartition(t *testing.T) {
+	const handle = "handle-single"
+	const role = "MYROLE"
+
+	rows := [][]string{
+		granteeRow(role, "USER", "alice"),
+		granteeRow(role, "ROLE", "SYSADMIN"),
+	}
+	server := serveGrantees(t, handle, rows, nil)
+	defer server.Close()
+
+	client, err := New(server.URL, JWTConfig{}, &http.Client{})
+	require.NoError(t, err)
+
+	grantees, nextCursor, err := client.ListAccountRoleGrantees(context.Background(), role, "")
+	require.NoError(t, err)
+	assert.Empty(t, nextCursor, "single partition should produce no next cursor")
+	require.Len(t, grantees, 2)
+	assert.Equal(t, AccountRoleGrantee{RoleName: role, GranteeType: "USER", GranteeName: "alice"}, grantees[0])
+	assert.Equal(t, AccountRoleGrantee{RoleName: role, GranteeType: "ROLE", GranteeName: "SYSADMIN"}, grantees[1])
+}
+
+func TestListAccountRoleGrantees_MultiPartition(t *testing.T) {
+	const handle = "handle-multi"
+	const role = "MYROLE"
+
+	partition0 := [][]string{
+		granteeRow(role, "USER", "alice"),
+		granteeRow(role, "ROLE", "SYSADMIN"),
+	}
+	partition1 := [][]string{
+		granteeRow(role, "USER", "bob"),
+	}
+	server := serveGrantees(t, handle, partition0, partition1)
+	defer server.Close()
+
+	client, err := New(server.URL, JWTConfig{}, &http.Client{})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Page 1: empty cursor → executes query, returns partition 0 + cursor.
+	page1, cursor1, err := client.ListAccountRoleGrantees(ctx, role, "")
+	require.NoError(t, err)
+	require.Len(t, page1, 2)
+	assert.Equal(t, "alice", page1[0].GranteeName)
+	assert.Equal(t, "USER", page1[0].GranteeType)
+	assert.Equal(t, "SYSADMIN", page1[1].GranteeName)
+	assert.Equal(t, "ROLE", page1[1].GranteeType)
+	assert.NotEmpty(t, cursor1)
+
+	// Page 2: cursor from page 1 → fetches ?partition=1, no further cursor.
+	page2, cursor2, err := client.ListAccountRoleGrantees(ctx, role, cursor1)
+	require.NoError(t, err)
+	require.Len(t, page2, 1)
+	assert.Equal(t, "bob", page2[0].GranteeName)
+	assert.Equal(t, "USER", page2[0].GranteeType)
+	assert.Empty(t, cursor2, "last partition should return empty cursor")
+}

--- a/pkg/snowflake/client.go
+++ b/pkg/snowflake/client.go
@@ -42,9 +42,13 @@ type (
 		AccountUrl       string
 		StatementsApiUrl *url.URL
 	}
+	PartitionInfo struct {
+		RowCount int `json:"rowCount"`
+	}
 	ResultSetMetadata struct {
-		NumRows  int       `json:"numRows"`
-		RowTypes []RowType `json:"rowType"`
+		NumRows       int             `json:"numRows"`
+		RowTypes      []RowType       `json:"rowType"`
+		PartitionInfo []PartitionInfo `json:"partitionInfo"`
 	}
 	StatementsApiResponseBase struct {
 		ResultSetMetadata ResultSetMetadata `json:"resultSetMetadata"`
@@ -232,6 +236,31 @@ func (c *Client) GetStatementResponse(ctx context.Context, statementHandle strin
 	if err != nil {
 		return nil, err
 	}
+
+	return c.NewRequest(
+		ctx,
+		http.MethodGet,
+		u,
+		uhttp.WithAcceptJSONHeader(),
+		uhttp.WithHeader(AuthTypeHeaderKey, AuthTypeHeaderValue),
+	)
+}
+
+// https://docs.snowflake.com/en/developer-guide/sql-api/handling-responses#getting-the-results-from-the-response.
+func (c *Client) GetStatementPartition(ctx context.Context, statementHandle string, partitionID int) (*http.Request, error) {
+	stringUrl, err := url.JoinPath(c.StatementsApiUrl.String(), statementHandle)
+	if err != nil {
+		return nil, err
+	}
+
+	u, err := url.Parse(stringUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	q.Set("partition", strconv.Itoa(partitionID))
+	u.RawQuery = q.Encode()
 
 	return c.NewRequest(
 		ctx,


### PR DESCRIPTION
Snowflakes [may partition the SQL result](https://docs.snowflake.com/en/developer-guide/sql-api/handling-responses#retrieving-additional-partitions). The first call has the partitions metadata, subsequent request are made to <handle>?partition=<partition#>