### PR TITLE
CXH-1935: add Snowflake license (edition and seats) sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ Compare both outputs. If both outputs match, the user correctly configured their
 To sync secrets the account needs this role
 permission https://docs.snowflake.com/en/sql-reference/sql/show-secrets#access-control-requirements
 
+### License data
+
+The connector can sync a `license` resource that reports the Snowflake edition
+(Standard, Enterprise, or Business Critical) and, for single-account
+organizations, the account's user count as consumed seats. This resource type is
+opt-in and requires connecting with an account that can read organization-level
+details (`GLOBALORGADMIN` on the organization account). When that access is not
+available, license sync is skipped and the rest of the sync is unaffected.
+
 ### Excluding Databases from Sync
 
 Use `--excluded-databases` (or `BATON_EXCLUDED_DATABASES`) to skip one or more databases entirely. Excluded databases and all of their tables are omitted from every sync. Matching is case-insensitive.

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -48,6 +48,28 @@
     },
     {
       "resourceType": {
+        "id": "license",
+        "displayName": "License",
+        "traits": [
+          "TRAIT_LICENSE_PROFILE"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.OptInRequired"
+          }
+        ]
+      },
+      "capabilities": [
+        "CAPABILITY_SYNC"
+      ],
+      "permissions": {},
+      "optInRequired": true
+    },
+    {
+      "resourceType": {
         "id": "rsa_public_key",
         "displayName": "RSA Public Key",
         "traits": [

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -21,8 +21,13 @@ sidebarTitle: Snowflake
 | Integrations | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | |
 | Secrets | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | |
 | RSA Public Keys | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | |
+| Licenses | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | |
 
 The Snowflake connector supports [account provisioning](/product/admin/account-provisioning).
+
+<Note>
+**License data is opt-in and requires an organization account.** License resources report the Snowflake edition (Standard, Enterprise, or Business Critical) and, for single-account organizations, the number of users as consumed seats. Reading it requires connecting with an account that can view organization-level details, so enable this capability only when that access is available.
+</Note>
 
 [This connector can sync secrets](/product/admin/inventory) and display them on the **Inventory** page.
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -29,6 +29,7 @@ func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.Reso
 		newDatabaseBuilder(d.Client, d.SyncSecrets, d.excludedDatabases),
 		newTableBuilder(d.Client),
 		newIntegrationBuilder(d.Client),
+		newLicenseBuilder(d.Client),
 	}
 
 	if d.SyncSecrets {

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -1,0 +1,106 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-snowflake/pkg/snowflake"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+)
+
+type licenseBuilder struct {
+	resourceType *v2.ResourceType
+	client       *snowflake.Client
+}
+
+func (l *licenseBuilder) ResourceType(_ context.Context) *v2.ResourceType {
+	return licenseResourceType
+}
+
+func (l *licenseBuilder) List(
+	ctx context.Context,
+	_ *v2.ResourceId,
+	_ rs.SyncOpAttrs,
+) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	logger := ctxzap.Extract(ctx)
+
+	accounts, statusCode, err := l.client.ListOrganizationAccounts(ctx)
+	if err != nil {
+		if snowflake.IsUnprocessableEntity(statusCode, err) {
+			logger.Warn("insufficient privileges to list organization accounts for license data; skipping license sync",
+				zap.Error(err),
+			)
+			return nil, nil, nil
+		}
+		return nil, nil, wrapError(err, "failed to list organization accounts")
+	}
+
+	userCount, err := l.client.CountUsers(ctx)
+	if err != nil {
+		logger.Warn("failed to count users for license data; proceeding without user count",
+			zap.Error(err),
+		)
+	}
+
+	var resources []*v2.Resource
+	for _, account := range accounts {
+		if account.Edition == "" {
+			continue
+		}
+
+		licenseName := fmt.Sprintf("Snowflake %s", account.Edition)
+		resourceID := fmt.Sprintf("%s:%s", account.AccountName, account.Edition)
+
+		traitOpts := []rs.LicenseProfileTraitOption{
+			rs.WithLicenseName(licenseName),
+		}
+		if userCount > 0 {
+			traitOpts = append(traitOpts, rs.WithLicenseSeats(0, userCount))
+		}
+
+		licenseTrait, err := rs.NewLicenseProfileTrait(traitOpts...)
+		if err != nil {
+			return nil, nil, wrapError(err, "failed to create license trait")
+		}
+
+		resource, err := rs.NewResource(
+			licenseName,
+			licenseResourceType,
+			resourceID,
+			rs.WithAnnotation(licenseTrait),
+		)
+		if err != nil {
+			return nil, nil, wrapError(err, "failed to create license resource")
+		}
+
+		resources = append(resources, resource)
+	}
+
+	return resources, &rs.SyncOpResults{}, nil
+}
+
+func (l *licenseBuilder) Entitlements(
+	_ context.Context,
+	_ *v2.Resource,
+	_ rs.SyncOpAttrs,
+) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, &rs.SyncOpResults{}, nil
+}
+
+func (l *licenseBuilder) Grants(
+	_ context.Context,
+	_ *v2.Resource,
+	_ rs.SyncOpAttrs,
+) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, &rs.SyncOpResults{}, nil
+}
+
+func newLicenseBuilder(client *snowflake.Client) *licenseBuilder {
+	return &licenseBuilder{
+		resourceType: licenseResourceType,
+		client:       client,
+	}
+}

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -27,22 +27,15 @@ func (l *licenseBuilder) List(
 ) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	logger := ctxzap.Extract(ctx)
 
-	accounts, statusCode, err := l.client.ListOrganizationAccounts(ctx)
+	accounts, _, err := l.client.ListOrganizationAccounts(ctx)
 	if err != nil {
-		if snowflake.IsUnprocessableEntity(statusCode, err) {
-			logger.Warn("insufficient privileges to list organization accounts for license data; skipping license sync",
-				zap.Error(err),
-			)
-			return nil, nil, nil
-		}
-		return nil, nil, wrapError(err, "failed to list organization accounts")
+		logger.Debug("skipping license sync: could not list organization accounts", zap.Error(err))
+		return nil, nil, nil
 	}
 
 	userCount, err := l.client.CountUsers(ctx)
 	if err != nil {
-		logger.Warn("failed to count users for license data; proceeding without user count",
-			zap.Error(err),
-		)
+		logger.Debug("proceeding without license seat count: could not count users", zap.Error(err))
 	}
 
 	var resources []*v2.Resource
@@ -57,8 +50,8 @@ func (l *licenseBuilder) List(
 		traitOpts := []rs.LicenseProfileTraitOption{
 			rs.WithLicenseName(licenseName),
 		}
-		if userCount > 0 {
-			traitOpts = append(traitOpts, rs.WithLicenseSeats(0, userCount))
+		if seats, ok := seatsForOrgAccounts(len(accounts), userCount); ok {
+			traitOpts = append(traitOpts, rs.WithLicenseSeats(0, seats))
 		}
 
 		licenseTrait, err := rs.NewLicenseProfileTrait(traitOpts...)
@@ -96,6 +89,16 @@ func (l *licenseBuilder) Grants(
 	_ rs.SyncOpAttrs,
 ) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	return nil, &rs.SyncOpResults{}, nil
+}
+
+// seatsForOrgAccounts returns the consumed-seat count to record on a license and
+// whether to record it. ACCOUNT_USAGE.USERS is scoped to the connected account, so
+// the count is only attributable when the org returns a single account.
+func seatsForOrgAccounts(accountCount int, userCount int64) (int64, bool) {
+	if accountCount == 1 && userCount > 0 {
+		return userCount, true
+	}
+	return 0, false
 }
 
 func newLicenseBuilder(client *snowflake.Client) *licenseBuilder {

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -27,10 +27,13 @@ func (l *licenseBuilder) List(
 ) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	logger := ctxzap.Extract(ctx)
 
-	accounts, _, err := l.client.ListOrganizationAccounts(ctx)
+	accounts, statusCode, err := l.client.ListOrganizationAccounts(ctx)
 	if err != nil {
-		logger.Debug("skipping license sync: could not list organization accounts", zap.Error(err))
-		return nil, nil, nil
+		if isOrgAccountsUnavailable(statusCode, err) {
+			logger.Debug("skipping license sync: organization accounts unavailable for this account", zap.Error(err))
+			return nil, nil, nil
+		}
+		return nil, nil, wrapError(err, "failed to list organization accounts")
 	}
 
 	userCount, err := l.client.CountUsers(ctx)
@@ -45,7 +48,7 @@ func (l *licenseBuilder) List(
 		}
 
 		licenseName := fmt.Sprintf("Snowflake %s", account.Edition)
-		resourceID := fmt.Sprintf("%s:%s", account.AccountName, account.Edition)
+		resourceID := account.AccountLocator
 
 		traitOpts := []rs.LicenseProfileTraitOption{
 			rs.WithLicenseName(licenseName),
@@ -99,6 +102,13 @@ func seatsForOrgAccounts(accountCount int, userCount int64) (int64, bool) {
 		return userCount, true
 	}
 	return 0, false
+}
+
+// isOrgAccountsUnavailable reports whether the error is the expected
+// "not an org account / no GLOBALORGADMIN" case (Snowflake returns 422), which is
+// safe to skip. ctx cancellation and 5xx return false so the sync surfaces them.
+func isOrgAccountsUnavailable(statusCode int, err error) bool {
+	return err != nil && snowflake.IsUnprocessableEntity(statusCode, err)
 }
 
 func newLicenseBuilder(client *snowflake.Client) *licenseBuilder {

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -105,10 +106,15 @@ func seatsForOrgAccounts(accountCount int, userCount int64) (int64, bool) {
 }
 
 // isOrgAccountsUnavailable reports whether the error is the expected
-// "not an org account / no GLOBALORGADMIN" case (Snowflake returns 422), which is
-// safe to skip. ctx cancellation and 5xx return false so the sync surfaces them.
+// "not an org account / no GLOBALORGADMIN" case, which is safe to skip. A regular
+// or trial account cannot run SHOW ORGANIZATION ACCOUNTS regardless of role and
+// Snowflake rejects it with 400; an org account without the role returns 422. Both
+// are skipped. ctx cancellation and 5xx return false so the sync surfaces them.
 func isOrgAccountsUnavailable(statusCode int, err error) bool {
-	return err != nil && snowflake.IsUnprocessableEntity(statusCode, err)
+	if err == nil {
+		return false
+	}
+	return statusCode == http.StatusBadRequest || snowflake.IsUnprocessableEntity(statusCode, err)
 }
 
 func newLicenseBuilder(client *snowflake.Client) *licenseBuilder {

--- a/pkg/connector/license_test.go
+++ b/pkg/connector/license_test.go
@@ -39,6 +39,7 @@ func TestIsOrgAccountsUnavailable(t *testing.T) {
 		want       bool
 	}{
 		{"no error", http.StatusOK, nil, false},
+		{"400 status code", http.StatusBadRequest, errors.New("400 Bad Request"), true},
 		{"422 status code", http.StatusUnprocessableEntity, errors.New("unprocessable entity"), true},
 		{"422 in error message", 0, errors.New("rpc error: code = Unknown desc = 422 Unprocessable Entity"), true},
 		{"500 propagates", http.StatusInternalServerError, errors.New("500 Internal Server Error"), false},

--- a/pkg/connector/license_test.go
+++ b/pkg/connector/license_test.go
@@ -1,6 +1,11 @@
 package connector
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+)
 
 func TestSeatsForOrgAccounts(t *testing.T) {
 	tests := []struct {
@@ -21,6 +26,28 @@ func TestSeatsForOrgAccounts(t *testing.T) {
 			if gotSeats != tt.wantSeats || gotOK != tt.wantOK {
 				t.Errorf("seatsForOrgAccounts(%d, %d) = (%d, %v), want (%d, %v)",
 					tt.accountCount, tt.userCount, gotSeats, gotOK, tt.wantSeats, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestIsOrgAccountsUnavailable(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		err        error
+		want       bool
+	}{
+		{"no error", http.StatusOK, nil, false},
+		{"422 status code", http.StatusUnprocessableEntity, errors.New("unprocessable entity"), true},
+		{"422 in error message", 0, errors.New("rpc error: code = Unknown desc = 422 Unprocessable Entity"), true},
+		{"500 propagates", http.StatusInternalServerError, errors.New("500 Internal Server Error"), false},
+		{"context canceled propagates", 0, context.Canceled, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isOrgAccountsUnavailable(tt.statusCode, tt.err); got != tt.want {
+				t.Errorf("isOrgAccountsUnavailable(%d, %v) = %v, want %v", tt.statusCode, tt.err, got, tt.want)
 			}
 		})
 	}

--- a/pkg/connector/license_test.go
+++ b/pkg/connector/license_test.go
@@ -1,0 +1,27 @@
+package connector
+
+import "testing"
+
+func TestSeatsForOrgAccounts(t *testing.T) {
+	tests := []struct {
+		name         string
+		accountCount int
+		userCount    int64
+		wantSeats    int64
+		wantOK       bool
+	}{
+		{"single account with users", 1, 5, 5, true},
+		{"single account no users", 1, 0, 0, false},
+		{"multiple accounts", 3, 5, 0, false},
+		{"no accounts", 0, 5, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSeats, gotOK := seatsForOrgAccounts(tt.accountCount, tt.userCount)
+			if gotSeats != tt.wantSeats || gotOK != tt.wantOK {
+				t.Errorf("seatsForOrgAccounts(%d, %d) = (%d, %v), want (%d, %v)",
+					tt.accountCount, tt.userCount, gotSeats, gotOK, tt.wantSeats, tt.wantOK)
+			}
+		})
+	}
+}

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -45,6 +45,12 @@ var (
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_APP},
 		Annotations: getSkipEntitlementsAnnotation(),
 	}
+	licenseResourceType = &v2.ResourceType{
+		Id:          "license",
+		DisplayName: "License",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_LICENSE_PROFILE},
+		Annotations: getLicenseAnnotations(),
+	}
 )
 
 func getSkipEntitlementsAnnotation() annotations.Annotations {
@@ -52,4 +58,12 @@ func getSkipEntitlementsAnnotation() annotations.Annotations {
 	annotations.Update(&v2.SkipEntitlementsAndGrants{})
 
 	return annotations
+}
+
+func getLicenseAnnotations() annotations.Annotations {
+	annos := annotations.Annotations{}
+	annos.Update(&v2.SkipEntitlementsAndGrants{})
+	annos.Update(&v2.OptInRequired{})
+
+	return annos
 }

--- a/pkg/snowflake/client.go
+++ b/pkg/snowflake/client.go
@@ -26,6 +26,9 @@ const (
 	AuthTypeHeaderValue = "KEYPAIR_JWT"
 	RoleHeaderKey       = "X-Snowflake-Role"
 	UserAdminRole       = "USERADMIN"
+	// GlobalOrgAdminRole is required by SHOW ORGANIZATION ACCOUNTS. The SQL API takes
+	// the role in the request body, not the RoleHeaderKey header.
+	GlobalOrgAdminRole = "GLOBALORGADMIN"
 )
 
 const (
@@ -60,6 +63,7 @@ type (
 	StatementsApiRequestBody struct {
 		Statement  string                      `json:"statement"`
 		Parameters StatementsRequestParameters `json:"parameters"`
+		Role       string                      `json:"role,omitempty"`
 	}
 	QueryParameter struct {
 		Type  string `json:"type"`
@@ -202,7 +206,11 @@ func New(accountUrl string, jwtConfig JWTConfig, httpClient *http.Client) (*Clie
 }
 
 func (c *Client) PostStatementRequest(ctx context.Context, queries []string) (*http.Request, error) {
-	body := &StatementsApiRequestBody{}
+	return c.PostStatementRequestWithRole(ctx, queries, "")
+}
+
+func (c *Client) PostStatementRequestWithRole(ctx context.Context, queries []string, role string) (*http.Request, error) {
+	body := &StatementsApiRequestBody{Role: role}
 	if len(queries) == 1 {
 		body.Statement = queries[0]
 	} else {

--- a/pkg/snowflake/client_test.go
+++ b/pkg/snowflake/client_test.go
@@ -1,0 +1,25 @@
+package snowflake
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestStatementsApiRequestBodyRole(t *testing.T) {
+	withRole, err := json.Marshal(StatementsApiRequestBody{Statement: "SHOW ORGANIZATION ACCOUNTS;", Role: GlobalOrgAdminRole})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(withRole), `"role":"GLOBALORGADMIN"`) {
+		t.Errorf("expected role in request body, got %s", withRole)
+	}
+
+	noRole, err := json.Marshal(StatementsApiRequestBody{Statement: "SHOW USERS;"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(noRole), "role") {
+		t.Errorf("expected role omitted when empty, got %s", noRole)
+	}
+}

--- a/pkg/snowflake/organization.go
+++ b/pkg/snowflake/organization.go
@@ -1,0 +1,127 @@
+package snowflake
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
+)
+
+var organizationAccountStructFieldToColumnMap = map[string]string{
+	"OrganizationName": "organization_name",
+	"AccountName":      "account_name",
+	"RegionGroup":      "region_group",
+	"SnowflakeRegion":  "snowflake_region",
+	"Edition":          "edition",
+	"AccountURL":       "account_url",
+	"AccountLocator":   "account_locator",
+}
+
+type (
+	OrganizationAccount struct {
+		OrganizationName string
+		AccountName      string
+		RegionGroup      string
+		SnowflakeRegion  string
+		Edition          string
+		AccountURL       string
+		AccountLocator   string
+	}
+	ListOrganizationAccountsRawResponse struct {
+		StatementsApiResponseBase
+	}
+)
+
+func (o *OrganizationAccount) GetColumnName(fieldName string) string {
+	return organizationAccountStructFieldToColumnMap[fieldName]
+}
+
+func (r *ListOrganizationAccountsRawResponse) GetOrganizationAccounts() ([]OrganizationAccount, error) {
+	var accounts []OrganizationAccount
+	for _, row := range r.Data {
+		account := &OrganizationAccount{}
+		if err := r.ResultSetMetadata.ParseRow(account, row); err != nil {
+			return nil, err
+		}
+		accounts = append(accounts, *account)
+	}
+	return accounts, nil
+}
+
+func (c *Client) ListOrganizationAccounts(ctx context.Context) ([]OrganizationAccount, int, error) {
+	queries := []string{"SHOW ORGANIZATION ACCOUNTS;"}
+
+	req, err := c.PostStatementRequest(ctx, queries)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var response ListOrganizationAccountsRawResponse
+	resp1, err := c.Do(req, uhttp.WithJSONResponse(&response))
+	defer closeResponseBody(resp1)
+	if err != nil {
+		statusCode := 0
+		if resp1 != nil {
+			statusCode = resp1.StatusCode
+		}
+		return nil, statusCode, err
+	}
+
+	req, err = c.GetStatementResponse(ctx, response.StatementHandle)
+	if err != nil {
+		return nil, 0, err
+	}
+	resp2, err := c.Do(req, uhttp.WithJSONResponse(&response))
+	defer closeResponseBody(resp2)
+	if err != nil {
+		statusCode := 0
+		if resp2 != nil {
+			statusCode = resp2.StatusCode
+		}
+		return nil, statusCode, err
+	}
+
+	accounts, err := response.GetOrganizationAccounts()
+	if err != nil {
+		return nil, resp2.StatusCode, err
+	}
+
+	return accounts, resp2.StatusCode, nil
+}
+
+func (c *Client) CountUsers(ctx context.Context) (int64, error) {
+	queries := []string{"SELECT COUNT(*) FROM SNOWFLAKE.ACCOUNT_USAGE.USERS WHERE DELETED_ON IS NULL;"}
+
+	req, err := c.PostStatementRequest(ctx, queries)
+	if err != nil {
+		return 0, err
+	}
+
+	var response StatementsApiResponseBase
+	resp1, err := c.Do(req, uhttp.WithJSONResponse(&response))
+	defer closeResponseBody(resp1)
+	if err != nil {
+		return 0, err
+	}
+
+	req, err = c.GetStatementResponse(ctx, response.StatementHandle)
+	if err != nil {
+		return 0, err
+	}
+	resp2, err := c.Do(req, uhttp.WithJSONResponse(&response))
+	defer closeResponseBody(resp2)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(response.Data) == 0 || len(response.Data[0]) == 0 {
+		return 0, nil
+	}
+
+	count, err := strconv.ParseInt(response.Data[0][0], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}

--- a/pkg/snowflake/organization.go
+++ b/pkg/snowflake/organization.go
@@ -51,7 +51,7 @@ func (r *ListOrganizationAccountsRawResponse) GetOrganizationAccounts() ([]Organ
 func (c *Client) ListOrganizationAccounts(ctx context.Context) ([]OrganizationAccount, int, error) {
 	queries := []string{"SHOW ORGANIZATION ACCOUNTS;"}
 
-	req, err := c.PostStatementRequest(ctx, queries)
+	req, err := c.PostStatementRequestWithRole(ctx, queries, GlobalOrgAdminRole)
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
Snowflake now reports each account's edition and, for single-account organizations, its license seat usage; it's opt-in and needs an organization-level admin account to read.