### PR TITLE
CXP-784 Unquote Snowflake identifiers from SHOW GRANTS grantee columns

### DIFF
--- a/pkg/snowflake/account_role.go
+++ b/pkg/snowflake/account_role.go
@@ -62,7 +62,7 @@ func (r *ListAccountRoleGranteesRawResponse) GetAccountRoleGrantees() []AccountR
 	for _, accountRoleGrantee := range r.Data {
 		accountRoleGrantees = append(accountRoleGrantees, AccountRoleGrantee{
 			RoleName:    accountRoleGrantee[1],
-			GranteeName: accountRoleGrantee[3],
+			GranteeName: unquoteSnowflakeIdentifier(accountRoleGrantee[3]),
 			GranteeType: accountRoleGrantee[2],
 		})
 	}

--- a/pkg/snowflake/account_role_test.go
+++ b/pkg/snowflake/account_role_test.go
@@ -91,6 +91,107 @@ func TestListAccountRoleGrantees_SinglePartition(t *testing.T) {
 	assert.Equal(t, AccountRoleGrantee{RoleName: role, GranteeType: "ROLE", GranteeName: "SYSADMIN"}, grantees[1])
 }
 
+// TestListAccountRoleGrantees_UnquotesGranteeName verifies the CXP-784 fix: Snowflake's
+// SHOW GRANTS OF ROLE renders grantee names that require quoting (mixed case, spaces) wrapped
+// in double quotes, with any embedded double quote doubled. GranteeName must come back
+// unquoted so it matches the canonical (unquoted) ID that SHOW ROLES produces for the same
+// role - otherwise nested-role expansion and principal-ID matching silently fail.
+func TestListAccountRoleGrantees_UnquotesGranteeName(t *testing.T) {
+	const handle = "handle-quoted"
+	const role = "MYROLE"
+
+	rows := [][]string{
+		granteeRow(role, "ROLE", `"Data Engineer"`),
+		granteeRow(role, "USER", `"He said ""hi"""`),
+		granteeRow(role, "ROLE", "SYSADMIN"),
+	}
+	server := serveGrantees(t, handle, rows, nil)
+	defer server.Close()
+
+	client, err := New(server.URL, JWTConfig{}, &http.Client{})
+	require.NoError(t, err)
+
+	grantees, nextCursor, err := client.ListAccountRoleGrantees(context.Background(), role, "")
+	require.NoError(t, err)
+	assert.Empty(t, nextCursor)
+	require.Len(t, grantees, 3)
+	assert.Equal(t, "Data Engineer", grantees[0].GranteeName, "quoted mixed-case name should be unquoted")
+	assert.Equal(t, `He said "hi"`, grantees[1].GranteeName, "embedded escaped quotes should be unescaped")
+	assert.Equal(t, "SYSADMIN", grantees[2].GranteeName, "already-unquoted system role should be unaffected")
+}
+
+// accountRoleRowTypes matches the column layout ListAccountRoles' ParseRow expects for SHOW ROLES.
+func accountRoleRowTypes() []map[string]interface{} {
+	return []map[string]interface{}{
+		{"name": "name", "type": "text"},
+	}
+}
+
+// serveAccountRoles returns an httptest.Server implementing the Snowflake Statements API for
+// SHOW ROLES, returning a single page of rows.
+func serveAccountRoles(t *testing.T, handle string, rows [][]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+
+		switch r.Method {
+		case http.MethodPost:
+			_ = enc.Encode(map[string]interface{}{
+				"statementHandle": handle,
+			})
+		case http.MethodGet:
+			_ = enc.Encode(map[string]interface{}{
+				"statementHandle": handle,
+				"resultSetMetadata": map[string]interface{}{
+					"numRows": len(rows),
+					"rowType": accountRoleRowTypes(),
+				},
+				"data": rows,
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+}
+
+// TestListAccountRoles_MatchesUnquotedGranteeID is the acceptance-criteria regression test for
+// CXP-784: for a role whose name requires quoting in SHOW GRANTS output, the resource ID Baton
+// builds from SHOW ROLES (canonical, bare name) must exactly match the principal ID built from
+// the corresponding SHOW GRANTS OF ROLE grantee entry for that same role (unquoted by this fix).
+// Before the fix, these diverged whenever the role name contained spaces/mixed case, silently
+// breaking nested-role expansion.
+func TestListAccountRoles_MatchesUnquotedGranteeID(t *testing.T) {
+	const roleName = "Data Engineer"
+
+	rolesServer := serveAccountRoles(t, "handle-roles", [][]string{{roleName}})
+	defer rolesServer.Close()
+
+	rolesClient, err := New(rolesServer.URL, JWTConfig{}, &http.Client{})
+	require.NoError(t, err)
+
+	roles, err := rolesClient.ListAccountRoles(context.Background(), "", 100)
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+	assert.Equal(t, roleName, roles[0].Name, "SHOW ROLES-derived name must remain bare/unquoted")
+
+	granteesServer := serveGrantees(t, "handle-grantees", [][]string{
+		granteeRow("PARENT_ROLE", "ROLE", `"Data Engineer"`),
+	}, nil)
+	defer granteesServer.Close()
+
+	granteesClient, err := New(granteesServer.URL, JWTConfig{}, &http.Client{})
+	require.NoError(t, err)
+
+	grantees, _, err := granteesClient.ListAccountRoleGrantees(context.Background(), "PARENT_ROLE", "")
+	require.NoError(t, err)
+	require.Len(t, grantees, 1)
+
+	assert.Equal(t, roles[0].Name, grantees[0].GranteeName,
+		"resource ID from SHOW ROLES must byte-for-byte match the principal ID derived from SHOW GRANTS OF ROLE")
+}
+
 func TestListAccountRoleGrantees_MultiPartition(t *testing.T) {
 	const handle = "handle-multi"
 	const role = "MYROLE"

--- a/pkg/snowflake/identifier.go
+++ b/pkg/snowflake/identifier.go
@@ -1,0 +1,21 @@
+package snowflake
+
+import "strings"
+
+// unquoteSnowflakeIdentifier normalizes an identifier as rendered by Snowflake's
+// SHOW GRANTS * commands. Snowflake renders identifiers that require quoting (mixed
+// case, spaces, special characters) wrapped in double quotes, with any embedded
+// double quote doubled (Snowflake source name `He said "hi"` -> `"He said ""hi"""`).
+// SHOW ROLES/SHOW USERS/SHOW DATABASES list output, by contrast, always returns the
+// bare canonical name and must never be passed through this function - doing so
+// would change already-stable resource IDs.
+//
+// If s is not wrapped in double quotes, it is returned unchanged (defensive: some
+// grantee names, e.g. default uppercase system roles, are already bare).
+func unquoteSnowflakeIdentifier(s string) string {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return s
+	}
+	inner := s[1 : len(s)-1]
+	return strings.ReplaceAll(inner, `""`, `"`)
+}

--- a/pkg/snowflake/identifier_test.go
+++ b/pkg/snowflake/identifier_test.go
@@ -1,0 +1,61 @@
+package snowflake
+
+import "testing"
+
+func TestUnquoteSnowflakeIdentifier(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "already unquoted uppercase system role is unaffected",
+			in:   "SYSADMIN",
+			want: "SYSADMIN",
+		},
+		{
+			name: "already unquoted simple name is unaffected",
+			in:   "alice",
+			want: "alice",
+		},
+		{
+			name: "quoted mixed-case name with spaces is unquoted",
+			in:   `"Data Engineer"`,
+			want: "Data Engineer",
+		},
+		{
+			name: "quoted name with embedded escaped double quote",
+			in:   `"He said ""hi"""`,
+			want: `He said "hi"`,
+		},
+		{
+			name: "quoted name with unicode",
+			in:   `"Ingénieur Données"`,
+			want: "Ingénieur Données",
+		},
+		{
+			name: "empty string is unaffected",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "single quote character is not treated as a quoted pair",
+			in:   `"`,
+			want: `"`,
+		},
+		{
+			name: "case is never altered",
+			in:   `"MixedCase"`,
+			want: "MixedCase",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unquoteSnowflakeIdentifier(tt.in)
+			if got != tt.want {
+				t.Errorf("unquoteSnowflakeIdentifier(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/snowflake/table.go
+++ b/pkg/snowflake/table.go
@@ -302,6 +302,7 @@ func (r *ListTableGrantsRawResponse) GetTableGrants() ([]TableGrant, error) {
 		if err := r.ResultSetMetadata.ParseRow(grant, row); err != nil {
 			return nil, err
 		}
+		grant.GranteeName = unquoteSnowflakeIdentifier(grant.GranteeName)
 
 		grants = append(grants, *grant)
 	}

--- a/pkg/snowflake/table_test.go
+++ b/pkg/snowflake/table_test.go
@@ -223,6 +223,33 @@ func TestListTableGrants_SinglePartition(t *testing.T) {
 	assert.Equal(t, "SYSADMIN", grants[1].GranteeName)
 }
 
+// TestListTableGrants_UnquotesGranteeName verifies the CXP-784 fix: Snowflake's SHOW GRANTS
+// ON TABLE/VIEW renders grantee names that require quoting wrapped in double quotes, with
+// embedded double quotes doubled. GranteeName must come back unquoted so it matches the
+// canonical (unquoted) ID that SHOW ROLES/SHOW USERS produce for the same principal.
+func TestListTableGrants_UnquotesGranteeName(t *testing.T) {
+	const handle = "handle-quoted"
+
+	rows := [][]string{
+		tableGrantRow("SELECT", "ROLE", `"Data Engineer"`),
+		tableGrantRow("SELECT", "USER", `"He said ""hi"""`),
+		tableGrantRow("SELECT", "ROLE", "SYSADMIN"),
+	}
+	server := serveTableGrants(t, handle, rows, nil)
+	defer server.Close()
+
+	client, err := New(server.URL, JWTConfig{}, &http.Client{})
+	require.NoError(t, err)
+
+	grants, nextCursor, err := client.ListTableGrants(context.Background(), nil, "DB", "SCHEMA", "MYTABLE", testObjectKind, "")
+	require.NoError(t, err)
+	assert.Empty(t, nextCursor)
+	require.Len(t, grants, 3)
+	assert.Equal(t, "Data Engineer", grants[0].GranteeName, "quoted mixed-case name should be unquoted")
+	assert.Equal(t, `He said "hi"`, grants[1].GranteeName, "embedded escaped quotes should be unescaped")
+	assert.Equal(t, "SYSADMIN", grants[2].GranteeName, "already-unquoted system role should be unaffected")
+}
+
 func TestListTableGrants_MultiPartition(t *testing.T) {
 	const handle = "handle-multi"
 


### PR DESCRIPTION
SHOW GRANTS OF ROLE / SHOW GRANTS ON TABLE|VIEW render grantee names that require quoting (mixed case, spaces, special chars) wrapped in double quotes, while SHOW ROLES/SHOW USERS return the bare canonical name for the same identifier. The connector was using the quoted value verbatim to build principal IDs and GrantExpandable.EntitlementIds, which never matched the canonical ID - silently breaking nested-role expansion.

Add unquoteSnowflakeIdentifier and apply it only at the SHOW GRANTS parse boundaries (AccountRoleGrantee.GranteeName, TableGrant.GranteeName). IDs derived from SHOW ROLES/SHOW USERS/SHOW DATABASES are untouched.

Note for release: tenants with mixed-case/special-char role or user grantee names will see those specific grant records shift ID on next sync (old grant disappears, correct one appears) - expected, this is the bug being fixed.